### PR TITLE
Update scriptableobjectcreator fix

### DIFF
--- a/Assets/Utilities/Editor/Odin/Tools/ScriptableObjectCreator.cs
+++ b/Assets/Utilities/Editor/Odin/Tools/ScriptableObjectCreator.cs
@@ -21,7 +21,8 @@ namespace Rhinox.Utilities.Odin.Editor
                     t.IsClass &&
                     typeof(ScriptableObject).IsAssignableFrom(t) &&
                     !typeof(EditorWindow).IsAssignableFrom(t) &&
-                    !typeof(UnityEditor.Editor).IsAssignableFrom(t))
+                    !typeof(UnityEditor.Editor).IsAssignableFrom(t) &&
+                    !t.ImplementsOpenGenericClass(typeof(UnityEditor.ScriptableSingleton<>)))
         );
 
         private static readonly string[] IgnoredNamespaces = new[]

--- a/Assets/Utilities/package.json
+++ b/Assets/Utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.rhinox.open.utilities",
   "displayName": "Rhinox.Utilities",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "unity": "2019.3",
   "description": "Utility code for Unity projects.",
   "keywords": [


### PR DESCRIPTION
### Fixes
- UnityEditor.ScriptableSingleton<> was not supported for ScriptableObjectCreator, removed from list