### PR TITLE
Ftr/assetdatabaseext/upgrade error

### DIFF
--- a/Assets/Utilities/Editor/AssetDatabase/AssetDatabaseExt.cs
+++ b/Assets/Utilities/Editor/AssetDatabase/AssetDatabaseExt.cs
@@ -97,21 +97,32 @@ namespace Rhinox.Utilities.Editor
             {
                 lock (_lockObject)
                 {
-                    ++_completeCount;
-                    PLog.Info($"AssetDatabase.CompletionCollection: completed import stage {_completeCount} out of {_targetCount}");
-                    if (importChanges != null && importChanges.ImportedAssets != null)
+                    if (completedState == ImportState.Completed)
                     {
-                        foreach (var importedAsset in importChanges.ImportedAssets)
+                        ++_completeCount;
+                        PLog.Info($"AssetDatabase.CompletionCollection: completed import stage {_completeCount} out of {_targetCount}");
+                        if (importChanges != null && importChanges.ImportedAssets != null)
                         {
-                            if (CaseInsensitiveContains(_importedAssets, importedAsset))
+                            foreach (var importedAsset in importChanges.ImportedAssets)
                             {
-                                PLog.Warn($"Asset '{importedAsset}' was doubly imported, '{job.Name}', skipping... add");
-                                continue;
-                            }
-                            _importedAssets.Add(importedAsset);
-                        }
+                                if (CaseInsensitiveContains(_importedAssets, importedAsset))
+                                {
+                                    PLog.Warn(
+                                        $"Asset '{importedAsset}' was doubly imported, '{job.Name}', skipping... add");
+                                    continue;
+                                }
 
-                        PLog.Info($"AssetDatabase.CompletionCollection: added {importChanges.ImportedAssets.Count} assets (total: {_importedAssets.Count})");
+                                _importedAssets.Add(importedAsset);
+                            }
+
+                            PLog.Info(
+                                $"AssetDatabase.CompletionCollection: added {importChanges.ImportedAssets.Count} assets (total: {_importedAssets.Count})");
+                        }
+                    }
+                    else
+                    {
+                        ++_failedCount;
+                        PLog.Info($"AssetDatabase.CompletionCollection: finished import stage {job.Name} with state {completedState} (total stages: {_targetCount})");
                     }
 
                     if (IsComplete)

--- a/Assets/Utilities/Editor/AssetDatabase/AssetDatabaseExt.cs
+++ b/Assets/Utilities/Editor/AssetDatabase/AssetDatabaseExt.cs
@@ -17,6 +17,8 @@ namespace Rhinox.Utilities.Editor
         private static EditorCoroutine _jobQueueProcessor;
         private static IImportJob _runningJob;
 
+        public delegate void JobCompleteHandler(AssetChanges changes, bool failed);
+        
         public delegate void JobEventHandler(IImportJob job);
 
         public static event JobEventHandler JobStarted;
@@ -47,19 +49,19 @@ namespace Rhinox.Utilities.Editor
             return true;
         }
 
-        public static bool ImportAsset(string assetPath, string targetFolder, params IJobProcessor[] processors)
+        public static bool CreateAndRunImportAssetJob(string assetPath, string targetFolder, params IJobProcessor[] processors)
         {
             var importJob = JobFactory.CreateJob(assetPath, targetFolder, _logger, processors);
             return RegisterJob(importJob);
         }
 
-        public static bool ImportAssets(ICollection<string> files, string targetFolder, Action<AssetChanges> callback = null)
+        public static bool CreateAndRunImportAssetJob(ICollection<string> files, string targetFolder, JobCompleteHandler callback = null)
         {
             var completedImportProcessor = new CompletedImportProcessor(files.Count, callback);
             foreach (var file in files)
             {
                 string fullPath = FileHelper.GetFullPath(file, FileHelper.GetProjectPath());
-                if (!ImportAsset(fullPath, targetFolder, completedImportProcessor))
+                if (!CreateAndRunImportAssetJob(fullPath, targetFolder, completedImportProcessor))
                     completedImportProcessor.MarkFailed(fullPath);
             }
 
@@ -75,7 +77,7 @@ namespace Rhinox.Utilities.Editor
             public int CompleteCount => _completeCount;
             private readonly object _lockObject = new object();
             private readonly int _targetCount;
-            private readonly Action<AssetChanges> _callback;
+            private readonly JobCompleteHandler _callback;
             private bool _firedEvent = false;
 
             private readonly List<string> _importedAssets;
@@ -84,14 +86,14 @@ namespace Rhinox.Utilities.Editor
 
             public bool HasFailed => _failedCount > 0;
 
-            public CompletedImportProcessor(int targetCount, Action<AssetChanges> callback)
+            public CompletedImportProcessor(int targetCount, JobCompleteHandler callback)
             {
                 _targetCount = targetCount;
                 _callback = callback;
                 _importedAssets = new List<string>();
             }
             
-            public AssetChanges OnCompleted(IImportJob job, AssetChanges importChanges)
+            public AssetChanges OnCompleted(IImportJob job, ImportState completedState, AssetChanges importChanges)
             {
                 lock (_lockObject)
                 {
@@ -112,20 +114,30 @@ namespace Rhinox.Utilities.Editor
                         PLog.Info($"AssetDatabase.CompletionCollection: added {importChanges.ImportedAssets.Count} assets (total: {_importedAssets.Count})");
                     }
 
-                    if (CompleteCount >= _targetCount && !_firedEvent)
-                    {
-                        try
-                        {
-                            _callback?.Invoke(new AssetChanges(_importedAssets));
-                        }
-                        catch (Exception e)
-                        {
-                            PLog.Error($"AssetDatabase.ImportAssets ({job.Name}) callback failed: {e.ToString()}");
-                        }
-                    }
+                    if (IsComplete)
+                        TriggerFinishedCallback(job.Name);
                 }
 
                 return importChanges;
+            }
+
+            private void TriggerFinishedCallback(string jobIdentifier)
+            {
+                if (_firedEvent)
+                {
+                    PLog.Debug("Duplicate invoke of TriggerFinished, skipping...");
+                    return;
+                }
+                
+                try
+                {
+                    _firedEvent = true;
+                    _callback?.Invoke(new AssetChanges(_importedAssets), _failedCount > 0);
+                }
+                catch (Exception e)
+                {
+                    PLog.Error($"AssetDatabase.ImportAssets ({jobIdentifier}) callback failed: {e.ToString()}");
+                }
             }
 
             public void MarkFailed(string jobFile)
@@ -134,6 +146,9 @@ namespace Rhinox.Utilities.Editor
                 {
                     ++_failedCount;
                     PLog.Error($"AssetDatabase.CompletionCollection: failed import stage '{jobFile}' out of {_targetCount}");
+                    
+                    if (IsComplete)
+                        TriggerFinishedCallback(jobFile);
                 }
             }
             

--- a/Assets/Utilities/Editor/AssetDatabase/Jobs/IImportJob.cs
+++ b/Assets/Utilities/Editor/AssetDatabase/Jobs/IImportJob.cs
@@ -94,7 +94,7 @@ namespace Rhinox.Utilities.Editor
                 {
                     var importChanges = ImportChanges;
                     foreach (var processor in PostProcessors)
-                        importChanges = processor.OnCompleted(this, importChanges);
+                        importChanges = processor.OnCompleted(this, state, importChanges);
                 }
 
                 OnCompleted();

--- a/Assets/Utilities/Editor/AssetDatabase/Jobs/Processor/DumpContentInFolderProcessor.cs
+++ b/Assets/Utilities/Editor/AssetDatabase/Jobs/Processor/DumpContentInFolderProcessor.cs
@@ -19,11 +19,17 @@ namespace Rhinox.Utilities.Editor
             _importedFiles = new List<string>();
         }
 
-        public AssetChanges OnCompleted(IImportJob job, AssetChanges importChanges)
+        public AssetChanges OnCompleted(IImportJob job, ImportState completedState, AssetChanges importChanges)
         {
             if (importChanges == null || importChanges.ImportedAssets == null)
             {
                 PLog.Info($"Job '{job.Name}' cannot be post-processed, no ImportChanges detected. (PostProcessor: '{GetType().Name}')");
+                return null;
+            }
+            
+            if (completedState == ImportState.Failed || completedState == ImportState.Cancelled)
+            {
+                PLog.Warn($"Job '{job.Name}' cannot be post-processed, ImportJob was/has {completedState}.");
                 return null;
             }
             

--- a/Assets/Utilities/Editor/AssetDatabase/Jobs/Processor/IJobProcessor.cs
+++ b/Assets/Utilities/Editor/AssetDatabase/Jobs/Processor/IJobProcessor.cs
@@ -2,6 +2,6 @@
 {
     public interface IJobProcessor
     {
-        AssetChanges OnCompleted(IImportJob job, AssetChanges importChanges);
+        AssetChanges OnCompleted(IImportJob job, ImportState completedState, AssetChanges importChanges);
     }
 }

--- a/Assets/Utilities/package.json
+++ b/Assets/Utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.rhinox.open.utilities",
   "displayName": "Rhinox.Utilities",
-  "version": "1.1.20",
+  "version": "1.2.0",
   "unity": "2019.3",
   "description": "Utility code for Unity projects.",
   "keywords": [


### PR DESCRIPTION
### Modified
- BREAKING: AssetDatabaseExt.ImportAsset renamed to AssetDatabaseExt.CreateAndRunImportAssetJob
- Callback in CompletedImportProcessor now also contains information if the job failed
- AssetDatabaseExt: Failed imports no longer mark the build is finished without error state
- IJobProcessor: OnCompleted signature changed to include ImportState of job