### PR TITLE
Ftr/transform editor fixes

### DIFF
--- a/Assets/Utilities/Editor/CustomInspectors/TransformCompEditor.cs
+++ b/Assets/Utilities/Editor/CustomInspectors/TransformCompEditor.cs
@@ -222,7 +222,7 @@ namespace Rhinox.Utilities.Editor
 			if (addReset)
 			{
 				menu.AddItem("Reset", reset);
-				if (addCopy || addPaste)
+				if (addCopy && addPaste)
 					menu.AddSeparator(string.Empty);
 			}
 

--- a/Assets/Utilities/Editor/CustomInspectors/TransformCompEditor.cs
+++ b/Assets/Utilities/Editor/CustomInspectors/TransformCompEditor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Rhinox.GUIUtils;
 using Rhinox.GUIUtils.Editor;
@@ -15,7 +16,7 @@ namespace Rhinox.Utilities.Editor
 {
 	[CanEditMultipleObjects]
 	[CustomEditor(typeof(Transform), true)]
-	public class TransformCompEditor : UnityEditor.Editor
+	public class TransformCompEditor : DefaultEditorExtender<Transform>
 	{
 		private static class Properties
 		{
@@ -69,8 +70,9 @@ namespace Rhinox.Utilities.Editor
 		private static Quaternion? _rotationClipboard = null;
 		private static Vector3? _scaleClipboard = null;
 
-		protected void OnEnable()
+		protected override void OnEnable()
 		{ 
+			base.OnEnable();
 			Init();
 		}
 
@@ -184,10 +186,10 @@ namespace Rhinox.Utilities.Editor
 			}
 		}
 
-		private static void ShowPropertyContextMenu(SerializedProperty property, GenericMenu menu = null)
+		private static void FillPropertyContextMenu(SerializedProperty property, GenericMenu menu = null)
 		{
 			var t = typeof(EditorGUI);
-			var m = t.GetMethod("DoPropertyContextMenu", BindingFlags.NonPublic | BindingFlags.Static);
+			var m = t.GetMethod("FillPropertyContextMenu", BindingFlags.NonPublic | BindingFlags.Static);
 			m.Invoke(null, new object[] { property, null, menu });
 		}
 		
@@ -206,22 +208,40 @@ namespace Rhinox.Utilities.Editor
 			}
 				
 			var menu = new GenericMenu();
+			FillPropertyContextMenu(prop, menu);
+
+			var menuItems = menu.GetItems();
+
+			var addReset = !menuItems.Any(x => x.menuItem.EndsWith("Reset"));
+			var addCopy = !menuItems.Any(x => x.menuItem.EndsWith("Copy"));
+			var addPaste = !menuItems.Any(x => x.menuItem.EndsWith("Paste"));
+
+			if (menu.GetItemCount() > 0 && (addReset || addCopy || addPaste))
+				menu.AddSeparator(string.Empty);
+
+			if (addReset)
+			{
+				menu.AddItem("Reset", reset);
+				if (addCopy || addPaste)
+					menu.AddSeparator(string.Empty);
+			}
+
+			// Add copy and paste (can't really do one without the other)
+			if (addCopy && addPaste)
+			{
+				var content = new GUIContent("Copy");
+				if (canCopy) menu.AddItem(content, false, copy);
+				else menu.AddDisabledItem(content);
 				
-			var content = new GUIContent("Reset");
-			menu.AddItem(content, false, reset);
-			menu.AddSeparator(string.Empty);
-				
-			content = new GUIContent("Copy");
-			if (canCopy) menu.AddItem(content, false, copy);
-			else menu.AddDisabledItem(content);
-				
-			content = new GUIContent("Paste");
-			if (canPaste) menu.AddItem(content, false, paste);
-			else menu.AddDisabledItem(content);
-				
-			menu.AddSeparator(string.Empty);
-				
-			ShowPropertyContextMenu(prop, menu);
+				content = new GUIContent("Paste");
+				if (canPaste) menu.AddItem(content, false, paste);
+				else menu.AddDisabledItem(content);
+			}
+			
+			if (menu.GetItemCount() == 0)
+				return;
+			Event.current.Use();
+			menu.ShowAsContext();
 		}
 
 		private void DrawPosition()

--- a/Assets/Utilities/Editor/Tools/ScriptableObjectCreator.cs
+++ b/Assets/Utilities/Editor/Tools/ScriptableObjectCreator.cs
@@ -98,7 +98,7 @@ namespace Rhinox.Utilities.Editor
         protected override CustomMenuTree BuildMenuTree()
         {
             this.MenuWidth = 270;
-            this.WindowPadding = Vector4.zero;
+            this.WindowPadding = new RectOffset();
 
             CustomMenuTree tree = new CustomMenuTree();
 #if ODIN_INSPECTOR

--- a/Assets/Utilities/Editor/Windows/DependenciesManager/DependencyAsset.cs
+++ b/Assets/Utilities/Editor/Windows/DependenciesManager/DependencyAsset.cs
@@ -8,11 +8,11 @@ using Object = UnityEngine.Object;
 
 namespace Rhinox.Utilities.Editor
 {
-    public class DependencyAsset : ScriptableObject
+    public class DependencyAsset
     {
         public static DependencyAsset Create(string path)
         {
-            var dep = CreateInstance<DependencyAsset>();
+            var dep = new DependencyAsset();
             dep.Initialize(path);
             return dep;
         }
@@ -79,14 +79,14 @@ namespace Rhinox.Utilities.Editor
     {
         public new static Dependency Create(string path)
         {
-            var dep = CreateInstance<Dependency>();
+            var dep = new Dependency();
             dep.Initialize(path);
             return dep;
         }
 
         public static Dependency Create(Object reference, string path = null)
         {
-            var dep = CreateInstance<Dependency>();
+            var dep = new Dependency();
             dep.Initialize(reference, path);
             return dep;
         }

--- a/Assets/Utilities/package.json
+++ b/Assets/Utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.rhinox.open.utilities",
   "displayName": "Rhinox.Utilities",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "unity": "2019.3",
   "description": "Utility code for Unity projects.",
   "keywords": [
@@ -11,8 +11,8 @@
   ],
   "category": "Unity",
   "dependencies": {
-	"com.rhinox.open.lightspeed": "1.5.2",
-	"com.rhinox.open.guiutils": "2.5.0",
+	"com.rhinox.open.lightspeed": "1.5.3",
+	"com.rhinox.open.guiutils": "2.6.0",
 	"com.rhinox.open.perceptor": "0.2.0"
   },
   "repository": {

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -10,8 +10,8 @@
     }
   ],
   "dependencies": {
-    "com.rhinox.open.guiutils": "2.5.0",
-    "com.rhinox.open.lightspeed": "1.5.2",
+    "com.rhinox.open.guiutils": "2.6.0",
+    "com.rhinox.open.lightspeed": "1.5.3",
     "com.rhinox.open.perceptor": "0.2.0",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.editorcoroutines": "1.0.0",


### PR DESCRIPTION
### Modified
- Changes in Custom Transform Editor to not override Unity's innate context menu

### Fix
- Properly inherit Custom Transform Editor from DefaultEditorExtender
- Fixed DependencyAsset's display