### PR TITLE
Fix/guiutils 281

### DIFF
--- a/Assets/Tests/Example.cs
+++ b/Assets/Tests/Example.cs
@@ -16,6 +16,8 @@ public class GenericList : ToggleableList<GameObject>
 public class Example : MonoBehaviour
 {
     public SerializableType Type;
+    public SerializableGuid Guid;
+    public SceneReferenceData SceneTest;
     public readonly string[] Options = new[] { "One", "Two", "FortyTwo" };
 
     [Serializable]

--- a/Assets/Tests/Example.cs
+++ b/Assets/Tests/Example.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using Rhinox.GUIUtils.Attributes;
 using Rhinox.Lightspeed;
 using Rhinox.Lightspeed.Collections;
+using Rhinox.Utilities;
 using Sirenix.OdinInspector;
 using UnityEngine;
+using UnityEngine.Events;
 
 [Serializable]
 public class GenericList : ToggleableList<GameObject>
@@ -15,7 +17,10 @@ public class GenericList : ToggleableList<GameObject>
 [SmartFallbackDrawn(false)]
 public class Example : MonoBehaviour
 {
+    public UnityEvent EventUnity;
+    public BetterEvent StartEvent;
     public SerializableType Type;
+    public SerializableType Type2;
     public SerializableGuid Guid;
     public SceneReferenceData SceneTest;
     public readonly string[] Options = new[] { "One", "Two", "FortyTwo" };
@@ -46,6 +51,13 @@ public class Example : MonoBehaviour
 
     [SerializeReference]
     public SimplePair<bool, bool> MyPair;
+
+    private void Start()
+    {
+        StartEvent.AddListener(() => Debug.Log($"{name} Triggered From script"));
+        StartEvent += () => Debug.Log($"{name} Triggered From script 2");
+        StartEvent.Invoke();
+    }
 
     void OnGUI()
     {

--- a/Assets/Tests/Example.cs
+++ b/Assets/Tests/Example.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Rhinox.GUIUtils.Attributes;
+using Rhinox.Lightspeed;
 using Rhinox.Lightspeed.Collections;
 using Sirenix.OdinInspector;
 using UnityEngine;
@@ -14,6 +15,7 @@ public class GenericList : ToggleableList<GameObject>
 [SmartFallbackDrawn(false)]
 public class Example : MonoBehaviour
 {
+    public SerializableType Type;
     public readonly string[] Options = new[] { "One", "Two", "FortyTwo" };
 
     [Serializable]
@@ -27,7 +29,7 @@ public class Example : MonoBehaviour
 
     public List<StringWithOptions> ListOfOptions;
 
-    // Rotate a button 10 degrees clockwise when presed.
+    // Rotate a button 10 degrees clockwise when pressed.
 
     float rotAngle = 0;
     Vector2 pivotPoint;

--- a/Assets/Tests/ExampleRegularEditor.cs
+++ b/Assets/Tests/ExampleRegularEditor.cs
@@ -1,0 +1,9 @@
+using Rhinox.GUIUtils.Attributes;
+using Rhinox.Lightspeed;
+using UnityEngine;
+
+public class ExampleRegularEditor : MonoBehaviour
+{
+    [AssignableTypeFilter(typeof(MonoBehaviour))]
+    public SerializableType Type;
+}

--- a/Assets/Tests/ExampleRegularEditor.cs
+++ b/Assets/Tests/ExampleRegularEditor.cs
@@ -6,4 +6,9 @@ public class ExampleRegularEditor : MonoBehaviour
 {
     [AssignableTypeFilter(typeof(MonoBehaviour))]
     public SerializableType Type;
+    
+    public SerializableGuid Guid;
+    
+    public SceneReferenceData Scene;
+
 }

--- a/Assets/Tests/ExampleRegularEditor.cs.meta
+++ b/Assets/Tests/ExampleRegularEditor.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ad5b57921f274af0a8ce0b65467ffdc4
+timeCreated: 1682429370

--- a/Assets/Tests/ScriptableTest.cs
+++ b/Assets/Tests/ScriptableTest.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using Rhinox.GUIUtils.Attributes;
+using Rhinox.Lightspeed;
+using UnityEngine;
+
+public class ScriptableTest : ScriptableObject
+{
+    public List<float> Testlist;
+    public SerializableType Type;
+    public SceneReferenceData Data;
+}

--- a/Assets/Tests/ScriptableTest.cs.meta
+++ b/Assets/Tests/ScriptableTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 99dc1011dd9e433429e0fd7a10399d93
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/new scriptabletest.asset
+++ b/Assets/Tests/new scriptabletest.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 99dc1011dd9e433429e0fd7a10399d93, type: 3}
+  m_Name: new scriptabletest
+  m_EditorClassIdentifier: 
+  Data:
+    sceneGuid: 
+    scenePath: 

--- a/Assets/Tests/new scriptabletest.asset.meta
+++ b/Assets/Tests/new scriptabletest.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6b1c37ff334c44045b2c74af3866de07
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Utilities/BetterEvents/BetterEvent.cs
+++ b/Assets/Utilities/BetterEvents/BetterEvent.cs
@@ -5,10 +5,11 @@ using UnityEngine;
 
 namespace Rhinox.Utilities
 {
-    [Serializable]
+    [Serializable, HideLabel]
     public struct BetterEvent
     {
         [HideReferenceObjectPicker, ListDrawerSettings(CustomAddFunction = "GetDefaultBetterEvent", OnTitleBarGUI = "DrawInvokeButton")]
+        [LabelText("$property.Parent.NiceName")]
         public List<BetterEventEntry> Events;
 
         public BetterEvent(params BetterEventEntry[] entries)

--- a/Assets/Utilities/BetterEvents/BetterEventEntry.cs
+++ b/Assets/Utilities/BetterEvents/BetterEventEntry.cs
@@ -206,7 +206,7 @@ namespace Rhinox.Utilities
             else
             {
                 pTypes = pTypes.Append(info.ReturnType).ToArray();
-                if (args.Length == 0) delegateType = typeof(Func<>).MakeArrayType();
+                if (args.Length == 0) delegateType = typeof(Func<>).MakeGenericType(pTypes);
                 else if (args.Length == 1) delegateType = typeof(Func<,>).MakeGenericType(pTypes);
                 else if (args.Length == 2) delegateType = typeof(Func<,,>).MakeGenericType(pTypes);
                 else if (args.Length == 3) delegateType = typeof(Func<,,,>).MakeGenericType(pTypes);
@@ -221,7 +221,10 @@ namespace Rhinox.Utilities
                 Debug.LogError("Unsupported Method Type");
                 return;
             }
-
+            
+            if (info.IsStatic)
+                target = null;
+            
             var del = Delegate.CreateDelegate(delegateType, target, info);
             InitDelegate(del, Array.Empty<object>());
         }

--- a/Assets/Utilities/BetterEvents/BetterEventEntry.cs
+++ b/Assets/Utilities/BetterEvents/BetterEventEntry.cs
@@ -92,6 +92,7 @@ namespace Rhinox.Utilities
             {
                 var unityObjs = new List<UnityEngine.Object>();
                 unityObjs.Add(Delegate.Target as UnityEngine.Object);
+                _parameters = new List<object>();
                 _targetType = new SerializableType(Delegate.Method.DeclaringType);
                 _methodName = Delegate.Method.Name;
                 foreach (var parameterValue in ParameterValues)

--- a/Assets/Utilities/BetterEvents/BetterEventEntry.cs
+++ b/Assets/Utilities/BetterEvents/BetterEventEntry.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using Rhinox.Lightspeed;
 using UnityEngine;
+using Object = UnityEngine.Object;
 #if ODIN_INSPECTOR
 using Sirenix.Serialization;
 #endif
@@ -80,22 +81,32 @@ namespace Rhinox.Utilities
             var val = new OdinSerializedData() {Delegate = this.Delegate, ParameterValues = this.ParameterValues};
             this.bytes = SerializationUtility.SerializeValue(val, DataFormat.Binary, out this.unityReferences);
 #else
-            var unityObjs = new List<UnityEngine.Object>();
-            unityObjs.Add(Delegate.Target as UnityEngine.Object);
-            _targetType = new SerializableType(Delegate.Method.DeclaringType);
-            _methodName = Delegate.Method.Name;
-            foreach (var parameterValue in ParameterValues)
+            if (Delegate == null)
             {
-                if (parameterValue is UnityEngine.Object objParam)
-                {
-                    _parameters.Add(new UnityObjectParameter() { Index = unityObjs.Count });
-                    unityObjs.Add(objParam);
-                }
-                else
-                    _parameters.Add(parameterValue);
+                unityReferences = new List<Object>();
+                _parameters = new List<object>();
+                _targetType = null;
+                _methodName = null;
             }
+            else
+            {
+                var unityObjs = new List<UnityEngine.Object>();
+                unityObjs.Add(Delegate.Target as UnityEngine.Object);
+                _targetType = new SerializableType(Delegate.Method.DeclaringType);
+                _methodName = Delegate.Method.Name;
+                foreach (var parameterValue in ParameterValues)
+                {
+                    if (parameterValue is UnityEngine.Object objParam)
+                    {
+                        _parameters.Add(new UnityObjectParameter() { Index = unityObjs.Count });
+                        unityObjs.Add(objParam);
+                    }
+                    else
+                        _parameters.Add(parameterValue);
+                }
 
-            this.unityReferences = unityObjs;
+                this.unityReferences = unityObjs;
+            }
 #endif       
         }
 
@@ -106,6 +117,9 @@ namespace Rhinox.Utilities
             this.Delegate = val.Delegate;
             this.ParameterValues = val.ParameterValues;
 #else
+            if (_targetType == null || _targetType.Type == null)
+                return;
+            
             this.ParameterValues = new object[_parameters.Count];
             for (int i = 0; i < _parameters.Count; ++i)
             {

--- a/Assets/Utilities/BetterEvents/BetterEventEntry.cs
+++ b/Assets/Utilities/BetterEvents/BetterEventEntry.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Rhinox.Lightspeed;
+using Sirenix.OdinInspector;
 using UnityEngine;
 using Object = UnityEngine.Object;
 #if ODIN_INSPECTOR
@@ -14,17 +15,24 @@ namespace Rhinox.Utilities
     [Serializable]
     public class BetterEventEntry : ISerializationCallbackReceiver
     {
+        public BindingFlags AllowedFlags
+        {
+            get => _flags;
+            set => _flags = value;
+        }
+        
+        // Delegate so we can support both lambda/actions and bound MethodInfos
         [NonSerialized, HideInInspector] public Delegate Delegate;
 
         [NonSerialized, HideInInspector] public object[] ParameterValues;
 
+        [SerializeField, HideInInspector] private bool _initialized;
+        [SerializeField, HideInInspector] private BindingFlags _flags;
+
         public BetterEventEntry(Delegate del)
         {
-            if (del != null && del.Method != null)
-            {
-                this.Delegate = del;
-                this.ParameterValues = new object[del.Method.GetParameters().Length];
-            }
+            if (del != null)
+                InitDelegate(del, Array.Empty<object>());
         }
 
         /// <summary>
@@ -33,14 +41,17 @@ namespace Rhinox.Utilities
         /// </summary>
         public BetterEventEntry(Delegate del, params object[] parameters)
         {
-            if (del != null && del.Method != null)
-            {
-                this.Delegate = del;
-                Array.Resize(ref parameters, del.Method.GetParameters().Length);
-                this.ParameterValues = parameters;
-            }
+            if (del != null)
+                InitDelegate(del, parameters);
         }
-
+        
+        private void InitDelegate(Delegate del, object[] parameters)
+        {
+            this.Delegate = del;
+            Array.Resize(ref parameters, del.Method.GetParameters().Length);
+            this.ParameterValues = parameters;
+        }
+        
         public void Invoke()
         {
             if (this.Delegate != null && this.ParameterValues != null)
@@ -67,7 +78,8 @@ namespace Rhinox.Utilities
         [SerializeReference] private List<object> _parameters;
         [SerializeField] private SerializableType _targetType;
         [SerializeField] private string _methodName;
-        
+        [SerializeField] private SerializableType[] _methodParameterTypes;
+
         
         private struct UnityObjectParameter
         {
@@ -81,6 +93,12 @@ namespace Rhinox.Utilities
             var val = new OdinSerializedData() {Delegate = this.Delegate, ParameterValues = this.ParameterValues};
             this.bytes = SerializationUtility.SerializeValue(val, DataFormat.Binary, out this.unityReferences);
 #else
+            if (!_initialized)
+            {
+                _flags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy;
+                
+                _initialized = true;
+            }
             if (Delegate == null)
             {
                 unityReferences = new List<Object>();
@@ -95,6 +113,7 @@ namespace Rhinox.Utilities
                 _parameters = new List<object>();
                 _targetType = new SerializableType(Delegate.Method.DeclaringType);
                 _methodName = Delegate.Method.Name;
+                _methodParameterTypes = Delegate.Method.GetParameters().Select(x => new SerializableType(x.ParameterType)).ToArray();
                 foreach (var parameterValue in ParameterValues)
                 {
                     if (parameterValue is UnityEngine.Object objParam)
@@ -134,11 +153,77 @@ namespace Rhinox.Utilities
             }
 
             var targetRef = unityReferences.FirstOrDefault();
-            if (targetRef == null)
-                this.Delegate = System.Delegate.CreateDelegate(_targetType.Type, _targetType.Type.GetMethod(_methodName, BindingFlags.Static | BindingFlags.Public));
-            else
-                this.Delegate = Delegate.CreateDelegate(_targetType.Type, targetRef, _methodName);
+            
+            MethodInfo[] possibleInfos = _targetType.Type.GetMethods(_flags);
+            var info = possibleInfos.FirstOrDefault(MatchParameter);
+            CreateAndAssignNewDelegate(targetRef, info);
 #endif
+        }
+
+        private bool MatchParameter(MethodInfo info)
+        {
+            if (info.Name != _methodName)
+                return false;
+            
+            var parameters = info.GetParameters();
+            
+            if (parameters.Length != _methodParameterTypes.Length)
+                return false;
+
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                if (parameters[i].ParameterType != _methodParameterTypes[i])
+                    return false;
+            }
+
+            return true;
+        }
+
+        public void CreateAndAssignNewDelegate(object target, MethodInfo info)
+        {
+            if (info == null)
+            {
+                Delegate = null;
+                return;
+            }
+            
+            var pTypes = info.GetParameters().Select(x => x.ParameterType).ToArray();
+            var args = new object[pTypes.Length];
+
+            Type delegateType = null;
+
+            if (info.ReturnType == typeof(void))
+            {
+                if (args.Length == 0) delegateType = typeof(Action);
+                else if (args.Length == 1) delegateType = typeof(Action<>).MakeGenericType(pTypes);
+                else if (args.Length == 2) delegateType = typeof(Action<,>).MakeGenericType(pTypes);
+                else if (args.Length == 3) delegateType = typeof(Action<,,>).MakeGenericType(pTypes);
+                else if (args.Length == 4) delegateType = typeof(Action<,,,>).MakeGenericType(pTypes);
+                else if (args.Length == 5) delegateType = typeof(Action<,,,,>).MakeGenericType(pTypes);
+                else if (args.Length == 6) delegateType = typeof(Action<,,,,,>).MakeGenericType(pTypes);
+                else if (args.Length == 7) delegateType = typeof(Action<,,,,,,>).MakeGenericType(pTypes);
+            }
+            else
+            {
+                pTypes = pTypes.Append(info.ReturnType).ToArray();
+                if (args.Length == 0) delegateType = typeof(Func<>).MakeArrayType();
+                else if (args.Length == 1) delegateType = typeof(Func<,>).MakeGenericType(pTypes);
+                else if (args.Length == 2) delegateType = typeof(Func<,,>).MakeGenericType(pTypes);
+                else if (args.Length == 3) delegateType = typeof(Func<,,,>).MakeGenericType(pTypes);
+                else if (args.Length == 4) delegateType = typeof(Func<,,,,>).MakeGenericType(pTypes);
+                else if (args.Length == 5) delegateType = typeof(Func<,,,,,>).MakeGenericType(pTypes);
+                else if (args.Length == 6) delegateType = typeof(Func<,,,,,,>).MakeGenericType(pTypes);
+                else if (args.Length == 7) delegateType = typeof(Func<,,,,,,,>).MakeGenericType(pTypes);
+            }
+            
+            if (delegateType == null)
+            {
+                Debug.LogError("Unsupported Method Type");
+                return;
+            }
+
+            var del = Delegate.CreateDelegate(delegateType, target, info);
+            InitDelegate(del, Array.Empty<object>());
         }
 
         #endregion

--- a/Assets/Utilities/Configuration/CustomProjectSettings.cs
+++ b/Assets/Utilities/Configuration/CustomProjectSettings.cs
@@ -183,12 +183,12 @@ namespace Rhinox.Utilities
             return settings;
         }
         
+#if UNITY_EDITOR
         private static void UpdateWriteTime()
         {
             _lastFileUpdateTime = File.GetLastWriteTime(FullSettingsPath);
         }
         
-#if UNITY_EDITOR
         public override bool HasBackingFileChanged()
         {
             return File.GetLastWriteTime(SettingsPath) != _lastFileUpdateTime;

--- a/Assets/Utilities/Configuration/Loading/IConfigLoader.cs
+++ b/Assets/Utilities/Configuration/Loading/IConfigLoader.cs
@@ -42,13 +42,13 @@ namespace Rhinox.Utilities
             try
             {
                 PLog.Debug($"Initialize IniParser for {path}");
-                new ManagedCoroutine(loader(path)).OnFinished += (manual) =>
+                ManagedCoroutine.Begin(loader(path), (manual) =>
                 {
                     if (!manual)
                         ParseData(file);
                     CleanUp();
                     callback?.Invoke(file);
-                };
+                });
             }
             catch (Exception e)
             {

--- a/Assets/Utilities/Configuration/Loading/LoadableConfigFile.cs
+++ b/Assets/Utilities/Configuration/Loading/LoadableConfigFile.cs
@@ -1,11 +1,13 @@
 using System.Collections.Generic;
+using System.IO;
 using Rhinox.Lightspeed.IO;
 using Rhinox.Perceptor;
+using Sirenix.OdinInspector;
+using UnityEngine;
 
 namespace Rhinox.Utilities
 {
-    
-    public abstract class LoadableConfigFile<T, TLoader> : ConfigFile<T>, ILoadableConfigFile 
+    public abstract class LoadableConfigFile<T, TLoader> : ConfigFile<T>, ILoadableConfigFile
         where T : ConfigFile<T>
         where TLoader : IConfigLoader, new()
     {
@@ -22,6 +24,11 @@ namespace Rhinox.Utilities
         {
             _loader = new TLoader();
             base.Initialize();
+        }
+
+        private void OnValidate()
+        {
+            _isLoading = false;
         }
 
         public virtual bool Load(string path)
@@ -47,6 +54,8 @@ namespace Rhinox.Utilities
 
         public virtual bool Save(string path, bool overwrite = false)
         {
+            Initialize();
+            
             if (string.IsNullOrWhiteSpace(path) || 
                 (FileHelper.Exists(path) && !overwrite))
                 return false;

--- a/Assets/Utilities/Editor/Async/EditorCoroutineRunner.cs
+++ b/Assets/Utilities/Editor/Async/EditorCoroutineRunner.cs
@@ -16,8 +16,8 @@ namespace Rhinox.Utilities.Editor
             // force kills all running coroutines if something goes wrong.
             EditorUtility.ClearProgressBar();
             uiCoroutineState = null;
-            coroutineStates.Clear();
-            finishedThisUpdate.Clear();
+            coroutineStates?.Clear();
+            finishedThisUpdate?.Clear();
         }
 
         private static List<EditorCoroutineState> coroutineStates;

--- a/Assets/Utilities/Editor/CustomInspectors/TransformCompEditor.cs
+++ b/Assets/Utilities/Editor/CustomInspectors/TransformCompEditor.cs
@@ -212,13 +212,13 @@ namespace Rhinox.Utilities.Editor
 
 			var menuItems = menu.GetItems();
 
-			var addReset = !menuItems.Any(x => x.menuItem.EndsWith("Reset"));
-			var addCopy = !menuItems.Any(x => x.menuItem.EndsWith("Copy"));
-			var addPaste = !menuItems.Any(x => x.menuItem.EndsWith("Paste"));
+			var addReset = !menuItems.Any(x => x.Path.EndsWith("Reset"));
+			var addCopy = !menuItems.Any(x => x.Path.EndsWith("Copy"));
+			var addPaste =  !menuItems.Any(x => x.Path.EndsWith("Paste"));
 
 			if (menu.GetItemCount() > 0 && (addReset || addCopy || addPaste))
 				menu.AddSeparator(string.Empty);
-
+			
 			if (addReset)
 			{
 				menu.AddItem("Reset", reset);

--- a/Assets/Utilities/Editor/Drawers/BetterEventEntryDrawer.cs
+++ b/Assets/Utilities/Editor/Drawers/BetterEventEntryDrawer.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Rhinox.GUIUtils.Editor;
+using Rhinox.Lightspeed;
+using UnityEditor;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Rhinox.Utilities.Editor
+{
+    [CustomPropertyDrawer(typeof(BetterEventEntry))]
+    public class BetterEventEntryDrawer : BasePropertyDrawer<BetterEventEntry, BetterEventEntryDrawer.DrawerData>
+    {
+        public class DrawerData
+        {
+            public GenericHostInfo Info;
+            public Object LocalTarget;
+            public GUIContent ActiveContent;
+        }
+        
+        private class MethodInfoWrapper
+        {
+            public MethodInfo Info;
+            public string FullName;
+            
+            public MethodInfoWrapper(MethodInfo info)
+            {
+                Info = info;
+                FullName = GetMethodInfoRepresentation(info);
+            }
+
+            public override string ToString() => FullName;
+        }
+        
+        private PickerHandler _methodPicker;
+
+        private GUIContent _noneContent;
+
+        protected override void OnInitialize()
+        {
+            base.OnInitialize();
+
+            _noneContent = new GUIContent("No Function");
+        }
+
+        protected override DrawerData CreateData(GenericHostInfo info)
+        {
+            var value = info.GetSmartValue<BetterEventEntry>();
+            return new DrawerData()
+            {
+                Info = info,
+                ActiveContent = new GUIContent(GetMethodInfoRepresentation(value.Delegate.Method)),
+                LocalTarget = value.Delegate.Target as Object
+            };
+        }
+
+        protected override GenericHostInfo GetHostInfo(DrawerData data) => data.Info;
+        
+        protected override void DrawProperty(Rect position, ref DrawerData data, GUIContent label)
+        {
+            var objectPickerRect = position.AlignLeft(position.width / 2 - 1f);
+            var newTarget = EditorGUI.ObjectField(objectPickerRect, data.LocalTarget, typeof(Object), true);
+            if (!Equals(data.LocalTarget, newTarget))
+            {
+                data.LocalTarget = newTarget;
+                _methodPicker = null;
+            }
+            
+            var methodPickerRect = position.AlignRight(position.width / 2 - 1f);
+
+            var content = SmartValue?.Delegate == null ? _noneContent : data.ActiveContent;
+            
+            if (EditorGUI.DropdownButton(methodPickerRect, content, FocusType.Keyboard))
+                DoMethodDropdown(position, data);
+        }
+
+        private void DoMethodDropdown(Rect position, DrawerData data)
+        {
+            if (_methodPicker != null)
+                GenericPicker.Show(position, _methodPicker);
+            else
+                _methodPicker = GenericPicker.Show(position, null, GetMethodOptions(data), x => SetValue(x, data));
+        }
+
+        private void SetValue(MethodInfoWrapper wrapper, DrawerData data)
+        {
+            if (wrapper != null)
+            {
+                data.ActiveContent.text = wrapper.FullName;
+                SmartValue.CreateAndAssignNewDelegate(data, wrapper.Info);
+            }
+            else
+                SmartValue.Delegate = null;
+        }
+
+        private ICollection<MethodInfoWrapper> GetMethodOptions(DrawerData data)
+        {
+            var targets = new [] {data.LocalTarget};
+
+            return targets.SelectMany(x => GetMethodOptions(x)).ToArray();
+        }
+
+
+        private IEnumerable<MethodInfoWrapper> GetMethodOptions<T>(T target)
+            => GetMethodOptions(target?.GetType());
+        
+        private IEnumerable<MethodInfoWrapper> GetMethodOptions(Type type)
+        {
+            if (type == null)
+                yield break;
+            
+            foreach (var mi in type.GetMethods(SmartValue.AllowedFlags))
+            {
+                if (mi.CustomAttributes.Any(x => x.AttributeType == typeof(CompilerGeneratedAttribute)))
+                    continue;
+                
+                if (mi.IsSpecialName) // This makes it ignore properties
+                {
+                    if (!mi.Name.StartsWith("set_")) // except for set_ methods
+                        continue;
+                }
+                
+                yield return new MethodInfoWrapper(mi);
+            }
+        }
+
+        private static string GetMethodInfoRepresentation(MethodInfo info)
+        {
+            var types = info.GetParameters();
+            string name = info.Name;
+
+            if (info.IsSpecialName)
+            {
+                var i = name.IndexOf("_", StringComparison.Ordinal);
+                name = name.Substring(i+1);
+            }
+            
+            if (info.IsSpecialName)
+                return $"{types[0].Name} {name}";
+            
+            if (types.Any())
+            {
+                var typesStr = string.Join(", ", types.Select(x => x.ParameterType.Name));
+                return $"{info.ReturnType.Name} {name} ({typesStr})";
+            }
+
+            return $"{info.ReturnType.Name} {name} ()";
+        }
+    }
+}

--- a/Assets/Utilities/Editor/Drawers/BetterEventEntryDrawer.cs.meta
+++ b/Assets/Utilities/Editor/Drawers/BetterEventEntryDrawer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b3ee50f2734f437796081b2e8906b747
+timeCreated: 1683640573

--- a/Assets/Utilities/Editor/Drawers/SceneAttributeDrawer.cs
+++ b/Assets/Utilities/Editor/Drawers/SceneAttributeDrawer.cs
@@ -7,8 +7,8 @@ namespace Rhinox.Utilities.Editor
     using UnityEngine;
      
     [CustomPropertyDrawer (typeof (SceneAttribute))]
-    public class SceneAttributeDrawer : PropertyDrawer {
-     
+    public class SceneAttributeDrawer : PropertyDrawer
+    {
         public override void OnGUI (Rect position, SerializedProperty property, GUIContent label) {
          
             if (property.propertyType == SerializedPropertyType.String) {
@@ -28,15 +28,15 @@ namespace Rhinox.Utilities.Editor
             else
                 EditorGUI.LabelField (position, label.text, "Use [Scene] with strings.");
         }
-        protected SceneAsset GetSceneObject(string sceneObjectName) {
-            if (string.IsNullOrEmpty(sceneObjectName)) {
+        protected SceneAsset GetSceneObject(string sceneObjectName)
+        {
+            if (string.IsNullOrEmpty(sceneObjectName))
                 return null;
-            }
      
-            foreach (var editorScene in EditorBuildSettings.scenes) {
-                if (editorScene.path.IndexOf(sceneObjectName) != -1) {
+            foreach (var editorScene in EditorBuildSettings.scenes)
+            {
+                if (editorScene.path.IndexOf(sceneObjectName) != -1)
                     return AssetDatabase.LoadAssetAtPath(editorScene.path, typeof(SceneAsset)) as SceneAsset;
-                }
             }
             Debug.LogWarning("Scene [" + sceneObjectName + "] cannot be used. Add this scene to the 'Scenes in the Build' in build settings.");
             return null;

--- a/Assets/Utilities/Editor/Tools/PolyCounter.cs
+++ b/Assets/Utilities/Editor/Tools/PolyCounter.cs
@@ -91,9 +91,9 @@ namespace Rhinox.Utilities.Editor
             foreach (var go in Selection.gameObjects)
             {
                 if (IncludeChildren)
-                    renderers.AddRange(go.GetComponentsInChildren<MeshRenderer>());
+                    renderers.AddRange(go.GetComponentsInChildren<Renderer>());
                 else
-                    renderers.Add(go.GetComponent<MeshRenderer>());
+                    renderers.Add(go.GetComponent<Renderer>());
             }
 
             if (!IncludeLODs)
@@ -128,6 +128,10 @@ namespace Rhinox.Utilities.Editor
         private static void AddRenderer(Renderer renderer)
         {
             if (renderer == null) return;
+            
+            if (renderer is SkinnedMeshRenderer skinnedMeshRenderer)
+                _meshes.Add(skinnedMeshRenderer.sharedMesh);
+
             
             var filter = renderer.GetComponent<MeshFilter>();
             

--- a/Assets/Utilities/Editor/Tools/ScriptableObjectCreator.cs
+++ b/Assets/Utilities/Editor/Tools/ScriptableObjectCreator.cs
@@ -69,7 +69,7 @@ namespace Rhinox.Utilities.Editor
 
             var window = CreateInstance<ScriptableObjectCreator>();
             window.position = RectExtensions.AlignCenter(CustomEditorGUI.GetEditorWindowRect(), 800, 500);
-            window.titleContent = new GUIContent(path);
+            window.titleContent = new GUIContent($"Create new SO in folder {path}");
             window.targetFolder = path.Trim('/');
             window.ShowUtility();
         }
@@ -101,8 +101,8 @@ namespace Rhinox.Utilities.Editor
             this.WindowPadding = new RectOffset();
 
             CustomMenuTree tree = new CustomMenuTree();
-#if ODIN_INSPECTOR
             tree.DrawSearchToolbar = true;
+#if ODIN_INSPECTOR
             tree.DefaultMenuStyle = OdinMenuStyle.TreeViewStyle;
 #endif
             foreach (var entry in GetTypesForTree())

--- a/Assets/Utilities/Editor/Tools/ScriptableObjectCreator.cs
+++ b/Assets/Utilities/Editor/Tools/ScriptableObjectCreator.cs
@@ -143,7 +143,6 @@ namespace Rhinox.Utilities.Editor
             if (isBaseType && !string.IsNullOrWhiteSpace(t.Namespace) && MatchesIgnoredNamespace(t.Namespace))
                 return string.Empty;
 
-            var name = t.Name.Split('`').First().SplitCamelCase();
             var nameSpace = isBaseType ? string.Empty : t.Namespace;
             var basePath = GetMenuPathForType(t.BaseType, true);
             if (!string.IsNullOrWhiteSpace(basePath))
@@ -155,7 +154,7 @@ namespace Rhinox.Utilities.Editor
                 nameSpace += "/";
             }
 
-            return nameSpace + basePath + name;
+            return nameSpace + basePath + t.GetNiceName();
         }
 
         private static string Fixup(string nameSpace)

--- a/Assets/Utilities/Editor/Windows/AdvancedSearch/AdvancedSceneSearchOverview.cs
+++ b/Assets/Utilities/Editor/Windows/AdvancedSearch/AdvancedSceneSearchOverview.cs
@@ -131,7 +131,7 @@ namespace Rhinox.Utilities.Odin.Editor
         private SettingData _includeDisabled;
         private SettingData _onlyInSelection;
 
-        public AdvancedSceneSearchOverview(SlidePagedWindowNavigationHelper<object> pager) : base(pager)
+        public AdvancedSceneSearchOverview(SlidePageNavigationHelper<object> pager) : base(pager)
         {
             _pager = pager;
             _motorWrappers = new List<MotorWrapper>

--- a/Assets/Utilities/Editor/Windows/AdvancedSearch/AdvancedSceneSearchOverview.cs
+++ b/Assets/Utilities/Editor/Windows/AdvancedSearch/AdvancedSceneSearchOverview.cs
@@ -44,9 +44,9 @@ namespace Rhinox.Utilities.Odin.Editor
             public bool ShowInfo = true;
             public bool Highlighted = false;
             
-            public IRepaintRequest Repainter;
+            public IRepaintable Repainter;
 
-            public MotorWrapper(Func<ICollection<GameObject>> objFetcher, IRepaintRequest repainter)
+            public MotorWrapper(Func<ICollection<GameObject>> objFetcher, IRepaintable repainter)
             {
                 Motor = new AdvancedSceneSearchMotor();
                 Motor.Changed += OnMotorChanged;
@@ -122,7 +122,7 @@ namespace Rhinox.Utilities.Odin.Editor
                 Repainter?.RequestRepaint();
             }
 
-            public void UpdateRequestTarget(IRepaintRequest target)
+            public void UpdateRequestTarget(IRepaintable target)
             {
                 Repainter = target;
             }

--- a/Assets/Utilities/Editor/Windows/AdvancedSearch/AdvancedSceneSearchWindow.cs
+++ b/Assets/Utilities/Editor/Windows/AdvancedSearch/AdvancedSceneSearchWindow.cs
@@ -13,7 +13,8 @@ namespace Rhinox.Utilities.Odin.Editor
     /// </summary>
     public class AdvancedSceneSearchWindow : PagerEditorWindow<AdvancedSceneSearchWindow>, IHasCustomMenu
     {
-        protected override object RootPage => new AdvancedSceneSearchOverview(_pager);
+        private AdvancedSceneSearchOverview _root;
+        protected override object RootPage => _root ?? (_root = new AdvancedSceneSearchOverview(_pager));
         protected override string RootPageName => "Overview";
 
         [MenuItem(WindowHelper.FindToolsPrefix + "Advanced Scene Search", false, -98)]

--- a/Assets/Utilities/Editor/Windows/AdvancedSearch/SearchFilters/ComponentsContainer.cs
+++ b/Assets/Utilities/Editor/Windows/AdvancedSearch/SearchFilters/ComponentsContainer.cs
@@ -83,7 +83,7 @@ namespace Rhinox.Utilities.Odin.Editor
             [HorizontalGroup, CustomValueDrawer(nameof(DrawType))]
             public readonly SerializableType Type;
 
-            [HorizontalGroup(width: 50), CustomValueDrawer(nameof(DrawAmount)), OnValueChanged(nameof(TriggerChanged))]
+            [HorizontalGroup(width: 100), CustomValueDrawer(nameof(DrawAmount)), OnValueChanged(nameof(TriggerChanged))]
             public int Amount;
 
             [HorizontalGroup(width: 22), CustomValueDrawer(nameof(DrawExpanded)), HideLabel]
@@ -132,7 +132,7 @@ namespace Rhinox.Utilities.Odin.Editor
             {
                 if (value >= 0)
                 {
-                    EditorGUIUtility.labelWidth = 60;
+                    EditorGUIUtility.labelWidth = 55;
                     return EditorGUILayout.IntField(label, value, GUILayout.ExpandWidth(false));
                 }
 

--- a/Assets/Utilities/Editor/Windows/DependenciesManager/DependencyHomePage.cs
+++ b/Assets/Utilities/Editor/Windows/DependenciesManager/DependencyHomePage.cs
@@ -68,11 +68,14 @@ namespace Rhinox.Utilities.Editor
                 Objects.AddUnique(AssetDatabase.LoadAssetAtPath<Object>(path));
         }
 
-        [Button(ButtonSizes.Small), ButtonGroup("Add2"), GUIColor(.8f, .4f, .6f)]
-        public void Clear()
+        [Button(ButtonSizes.Small), ButtonGroup("Add2"), GUIColor(.4f, .8f, .6f)]
+        public void AddSelection()
         {
-            Objects.Clear();
-            _mainWindow.Clear();
+            foreach (var obj in Selection.objects)
+            {
+                var path = AssetDatabase.GetAssetPath(obj);
+                Objects.AddUnique(AssetDatabase.LoadAssetAtPath<Object>(path));
+            }
         }
 
         [Button(ButtonSizes.Small), ButtonGroup("Add2"), GUIColor(.4f, .8f, .6f)]
@@ -81,6 +84,13 @@ namespace Rhinox.Utilities.Editor
             var paths = _mainWindow.AssetManager.GetAssetsPaths("");
             foreach (var path in paths)
                 Objects.AddUnique(AssetDatabase.LoadAssetAtPath<Object>(path));
+        }
+        
+        [Button(ButtonSizes.Small), GUIColor(.8f, .4f, .6f)]
+        public void Clear()
+        {
+            Objects.Clear();
+            _mainWindow.Clear();
         }
     }
 }

--- a/Assets/Utilities/Editor/Windows/DependenciesManager/DependencyHomePage.cs
+++ b/Assets/Utilities/Editor/Windows/DependenciesManager/DependencyHomePage.cs
@@ -1,10 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Rhinox.GUIUtils.Attributes;
 using Rhinox.Lightspeed;
 using Sirenix.OdinInspector;
 using UnityEditor;
-using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace Rhinox.Utilities.Editor
 {
@@ -13,7 +14,7 @@ namespace Rhinox.Utilities.Editor
         [ListDrawerSettings(Expanded = true, NumberOfItemsPerPage = 12, DraggableItems = false)]
         [AssetsOnly, DrawAsUnityObject]
         public List<Object> Objects = new List<Object>();
-
+        
         private DependenciesWindow _mainWindow;
 
         public void Initialize(DependenciesWindow window)

--- a/Assets/Utilities/Editor/Windows/TexturePacker/TexturePackerWindow.cs
+++ b/Assets/Utilities/Editor/Windows/TexturePacker/TexturePackerWindow.cs
@@ -84,12 +84,12 @@ namespace Rhinox.Utilities.Editor
         }
     }
     
-    public class TexturePackerWindow : EditorWindow
+    public class TexturePackerWindow : EditorWindow, IRepaintRequest
     {
         private TexturePackerRoot _root = new TexturePackerRoot();
         
         private SmartPropertyView _propertyView;
-
+        
         /// ================================================================================================================
         /// METHODS
         [MenuItem(WindowHelper.ToolsPrefix + "Texture Packer", false, 202)]
@@ -108,10 +108,17 @@ namespace Rhinox.Utilities.Editor
         private void OnGUI()
         {
             if (_propertyView == null)
+            {
                 _propertyView = new SmartPropertyView(_root);
+                // _propertyView.RepaintRequested += RequestRepaint;
+            }
+            
             _propertyView.DrawLayout();
-            if (_propertyView.ShouldRepaint)
-                Repaint();
+        }
+
+        public void RequestRepaint()
+        {
+            Repaint();
         }
     }
 }

--- a/Assets/Utilities/Editor/Windows/TexturePacker/TexturePackerWindow.cs
+++ b/Assets/Utilities/Editor/Windows/TexturePacker/TexturePackerWindow.cs
@@ -62,7 +62,7 @@ namespace Rhinox.Utilities.Editor
                     break;
                 
                 default:
-                    EditorUtility.DisplayDialog("Cannot compute...", string.Format("The fileformat '{0}'", format), "OK");
+                    EditorUtility.DisplayDialog("Cannot compute...", $"The fileformat '{format}'", "OK");
                     break;
             }
 
@@ -84,7 +84,7 @@ namespace Rhinox.Utilities.Editor
         }
     }
     
-    public class TexturePackerWindow : EditorWindow, IRepaintRequest
+    public class TexturePackerWindow : EditorWindow
     {
         private TexturePackerRoot _root = new TexturePackerRoot();
         
@@ -110,7 +110,7 @@ namespace Rhinox.Utilities.Editor
             if (_propertyView == null)
             {
                 _propertyView = new SmartPropertyView(_root);
-                // _propertyView.RepaintRequested += RequestRepaint;
+                _propertyView.RepaintRequested += RequestRepaint;
             }
             
             _propertyView.DrawLayout();

--- a/Assets/Utilities/Editor/Windows/UnityIconsViewer.cs
+++ b/Assets/Utilities/Editor/Windows/UnityIconsViewer.cs
@@ -156,6 +156,7 @@ namespace Rhinox.Utilities.Editor
             var target = (UnityIcon)GetTargets().ElementAt(index);
 
             var propertyDrawer = new DrawablePropertyView(target);
+            propertyDrawer.RepaintRequested += Repaint;
             propertyDrawer.DrawLayout();
         }
 #endif

--- a/Assets/Utilities/Helpers.meta
+++ b/Assets/Utilities/Helpers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fe5adf8e5a41ccf4c9f0621afc1d083e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Utilities/Helpers/ApiHelper.cs
+++ b/Assets/Utilities/Helpers/ApiHelper.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Text;
 using System.Threading.Tasks;
+#if NEWTONSOFT
 using Newtonsoft.Json;
+#endif
 using Rhinox.Lightspeed;
 using UnityEngine;
 using UnityEngine.Networking;

--- a/Assets/Utilities/Helpers/ApiHelper.cs
+++ b/Assets/Utilities/Helpers/ApiHelper.cs
@@ -142,7 +142,7 @@ namespace Rhinox.Utilities
                     return true;
             }
             throw new NotImplementedException($"Unknown result type: {request.result}");
-#endif
+#else
             if (request.isHttpError)
             {
                 Debug.LogError(request.uri + ": HTTP Error: " + request.error);
@@ -155,6 +155,7 @@ namespace Rhinox.Utilities
             }
             
             return true;
+#endif
         }
         
         private string ToJson<T>(T o)

--- a/Assets/Utilities/Helpers/ApiHelper.cs
+++ b/Assets/Utilities/Helpers/ApiHelper.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Rhinox.Lightspeed;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace Unity.Helpers
+{
+    public class ApiHelper
+    {
+        private string _baseUrl;
+        
+        public ApiHelper(string url)
+        {
+            _baseUrl = url;
+        }
+        
+        public delegate void WebRequestAction(UnityWebRequest request);
+
+        public async Task Get(string path, WebRequestAction handleRequest)
+        {
+            string uri = $"{_baseUrl}{path}";
+            using (var request = UnityWebRequest.Get(uri))
+            {
+                // Request and wait for the desired page.
+                await request.SendWebRequest();
+                
+                if (HandleResult(request))
+                    handleRequest?.Invoke(request);
+            }
+        }
+
+        public async Task<T> Get<T>(string path)
+        {
+            string uri = $"{_baseUrl}{path}";
+            using (var request = UnityWebRequest.Get(uri))
+            {
+                // Request and wait for the desired page.
+                await request.SendWebRequest();
+
+                if (HandleResult(request))
+                    return FromJsonResult<T>(request);
+                
+                return default;
+            }
+        }
+
+        public T GetSync<T>(string path)
+        {
+            string uri = $"{_baseUrl}{path}";
+            using (var request = UnityWebRequest.Get(uri))
+            {
+                // Request and wait for the desired page.
+                var op = request.SendWebRequest();
+                while (!op.isDone)
+                {
+                }
+
+                return FromJsonResult<T>(request);
+            }
+        }
+
+        public async Task<TResult> Post<TResult>(string path, object o)
+        {
+            var json = JsonConvert.SerializeObject(o);
+            var result = await Post<TResult>(path, json);
+            return result;
+        }
+
+        public async Task Post(string path, object o, WebRequestAction handleRequest = null)
+        {
+            var json = JsonConvert.SerializeObject(o);
+            await Post(path, json, handleRequest);
+        }
+
+        public async Task Post(string path, string json, WebRequestAction handleRequest = null)
+        {
+            string uri = $"{_baseUrl}{path}";
+            using (var request = new UnityWebRequest(uri, "POST"))
+            {
+                byte[] bodyRaw = Encoding.UTF8.GetBytes(json);
+                request.uploadHandler = new UploadHandlerRaw(bodyRaw);
+                request.downloadHandler = new DownloadHandlerBuffer();
+                request.SetRequestHeader("Content-Type", "application/json");
+
+                // Request and wait for the desired page.
+                await request.SendWebRequest();
+
+                if (HandleResult(request))
+                    handleRequest?.Invoke(request);
+            }
+        }
+
+        public async Task<T> Post<T>(string path, string json)
+        {
+            string uri = $"{_baseUrl}{path}";
+            using (var request = new UnityWebRequest(uri, "POST"))
+            {
+                byte[] bodyRaw = Encoding.UTF8.GetBytes(json);
+                request.uploadHandler = new UploadHandlerRaw(bodyRaw);
+                request.downloadHandler = new DownloadHandlerBuffer();
+                request.SetRequestHeader("Content-Type", "application/json");
+
+                // Request and wait for the desired page.
+                await request.SendWebRequest();
+
+                return FromJsonResult<T>(request);
+            }
+        }
+
+        public TResult PostSync<TResult>(string path, object o)
+        {
+            var json = JsonConvert.SerializeObject(o);
+            return PostSync<TResult>(path, json);
+        }
+
+        public TResult PostSync<TResult>(string path, string json)
+        {
+            string uri = $"{_baseUrl}{path}";
+            using (var request = new UnityWebRequest(uri, "POST"))
+            {
+                byte[] bodyRaw = Encoding.UTF8.GetBytes(json);
+                request.uploadHandler = new UploadHandlerRaw(bodyRaw);
+                request.downloadHandler = new DownloadHandlerBuffer();
+                request.SetRequestHeader("Content-Type", "application/json");
+
+                // Request and wait for the desired page.
+                var op = request.SendWebRequest();
+                while (!op.isDone) { }
+
+                return FromJsonResult<TResult>(request);
+            }
+        }
+
+        private static bool HandleResult(UnityWebRequest request)
+        {
+            switch (request.result)
+            {
+                case UnityWebRequest.Result.ConnectionError:
+                case UnityWebRequest.Result.DataProcessingError:
+                    Debug.LogError(request.uri + ": Error: " + request.error);
+                    return false;
+                case UnityWebRequest.Result.ProtocolError:
+                    Debug.LogError(request.uri + ": HTTP Error: " + request.error);
+                    return false;
+                case UnityWebRequest.Result.Success:
+                    // Debug.Log(uri + ":\nReceived: " + request.downloadHandler.text);
+                    return true;
+            }
+
+            throw new NotImplementedException($"Unknown result type: {request.result}");
+        }
+
+        private static T FromJsonResult<T>(UnityWebRequest request)
+        {
+            if (typeof(T) == typeof(string))
+                return (T)(object)request.downloadHandler.text;
+            return JsonUtility.FromJson<T>(request.downloadHandler.text);
+        }
+    }
+}

--- a/Assets/Utilities/Helpers/ApiHelper.cs.meta
+++ b/Assets/Utilities/Helpers/ApiHelper.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 61c5f44ddbfbba74886ddbc651247fcd
+timeCreated: 1682589065

--- a/Assets/Utilities/ManagedCoroutine.cs
+++ b/Assets/Utilities/ManagedCoroutine.cs
@@ -87,6 +87,14 @@ namespace Rhinox.Utilities
 			return coroutine;
 		}
 		
+		public static ManagedCoroutine Begin(IEnumerator c, FinishedHandler callback)
+		{
+			var coroutine = new ManagedCoroutine(c);
+			coroutine.OnFinished += callback;
+			coroutine.Start();
+			return coroutine;
+		}
+		
 		/// Paused tasks are considered to be running.
 		public bool Running => _coroutine.Running;
 

--- a/Assets/Utilities/ManagedCoroutine.cs
+++ b/Assets/Utilities/ManagedCoroutine.cs
@@ -78,6 +78,14 @@ namespace Rhinox.Utilities
 
 			public override bool keepWaiting => !_coroutine.Finished;
 		}
+
+		public static ManagedCoroutine Begin(IEnumerator c, bool autoStart = true)
+		{
+			var coroutine = new ManagedCoroutine(c);
+			if (autoStart)
+				coroutine.Start();
+			return coroutine;
+		}
 		
 		/// Paused tasks are considered to be running.
 		public bool Running => _coroutine.Running;
@@ -97,13 +105,18 @@ namespace Rhinox.Utilities
 		public event FailedHandler OnFailed;
 
 		/// If autoStart is true (default) the task is automatically started upon construction.
+		[Obsolete("Use ManagedCoroutine.Begin instead")]
 		public ManagedCoroutine(IEnumerator c, bool autoStart = true)
+			: this(c)
+		{
+			if (autoStart) Start();
+		}
+
+		private ManagedCoroutine(IEnumerator c)
 		{
 			_coroutine = CoroutineManager.Create(c);
 			_coroutine.OnFinished += CoroutineOnFinished;
 			_coroutine.OnFailed += CoroutineOnFailed;
-
-			if (autoStart) Start();
 		}
 
 		public void Start() => _coroutine.Start();

--- a/Assets/Utilities/ObjectPool/ObjectPool.cs
+++ b/Assets/Utilities/ObjectPool/ObjectPool.cs
@@ -9,47 +9,45 @@ namespace Rhinox.Utilities
 {
 	public interface IObjectPool
 	{
-		bool AddToPool(GameObject prefab, int count);
-		bool AddToPool(GameObject prefab, int count, Transform parent);
-
-		GameObject PopFromPool(GameObject prefab, bool forceCreate = false, Vector3 position = default);
-
-		GameObject PopFromPool(GameObject prefab, Transform parent, bool forceCreate = false, Vector3 position = default);
-
-		T PopFromPool<T>(T poolObject, bool forceCreate = false, Vector3 position = default)
-			where T : Component;
+		bool AddToPool(GameObject template, int count);
+		bool AddToPool(GameObject template, Transform parent, int count);
 		
-		T PopFromPool<T>(T poolObject, Transform parent, bool forceCreate = false, Vector3 position = default)
-			where T : Component;
+		bool AddToPool<T>(T template, int count) where T : Component;
+		bool AddToPool<T>(T template, Transform parent, int count) where T : Component;
 
-		void PushToPool(GameObject obj);
+		GameObject PopFromPool(GameObject template, bool forceCreate = false, Vector3 position = default);
+		GameObject PopFromPool(GameObject template, Transform parent, bool forceCreate = false, Vector3 position = default);
+
+		T PopFromPool<T>(T template, bool forceCreate = false, Vector3 position = default) where T : Component;
+		T PopFromPool<T>(T template, Transform parent, bool forceCreate = false, Vector3 position = default) where T : Component;
+
+		void PushToPool(GameObject obj, bool preserveParent = true);
 		void PushToPool(GameObject obj, Transform parent);
-		void PushToPool(GameObject obj, GameObject prefab);
-		void PushToPool(GameObject obj, GameObject prefab, Transform parent);
+		void PushToPool(GameObject obj, GameObject template);
+		void PushToPool(GameObject obj, GameObject template, Transform parent);
 		
-		void PushToPool<T>(T obj) where T : Component;
+		void PushToPool<T>(T obj, bool preserveParent = true) where T : Component;
 		void PushToPool<T>(T obj, Transform parent) where T : Component;
-		void PushToPool<T>(T obj, T prefab) where T : Component;
-		void PushToPool<T>(T obj, T prefab, Transform parent) where T : Component;
+		void PushToPool<T>(T obj, T template) where T : Component;
+		void PushToPool<T>(T obj, T template, Transform parent) where T : Component;
 
 		void PushToPoolDelayed(GameObject obj, float time);
 		void PushToPoolDelayed(GameObject obj, float time, Transform parent);
-		void PushToPoolDelayed(GameObject obj, GameObject prefab, float time);
-		void PushToPoolDelayed(GameObject obj, GameObject prefab, float time, Transform parent);
+		void PushToPoolDelayed(GameObject obj, GameObject template, float time);
+		void PushToPoolDelayed(GameObject obj, GameObject template, float time, Transform parent);
 		
 		void PushToPoolDelayed<T>(T obj, float time) where T : Component;
-
 		void PushToPoolDelayed<T>(T obj, float time, Transform parent) where T : Component;
-		void PushToPoolDelayed<T>(T obj, T prefab, float time) where T : Component;
-		void PushToPoolDelayed<T>(T obj, T prefab, float time, Transform parent) where T : Component;
+		void PushToPoolDelayed<T>(T obj, T template, float time) where T : Component;
+		void PushToPoolDelayed<T>(T obj, T template, float time, Transform parent) where T : Component;
 
-		void ReleaseItems(GameObject prefab, bool destroyObjects = false);
+		void ReleaseItems(GameObject template, bool destroyObjects = false);
 		void ReleasePool();
 	}
 
 	public sealed class ObjectPool : MonoBehaviour, IObjectPool
 	{
-		private Dictionary<GameObject, Queue<GameObject>> _container = new Dictionary<GameObject, Queue<GameObject>>();
+		private Dictionary<GameObject, Queue<GameObject>> _objectsByTemplate = new Dictionary<GameObject, Queue<GameObject>>();
 
 		private bool _destroyed;
 		
@@ -85,38 +83,70 @@ namespace Rhinox.Utilities
 
 		private ObjectPool() { }
 
-		public bool AddToPool(GameObject prefab, int count)
-			=> AddToPool(prefab, count, transform);
+		public bool AddToPool<T>(T template, int count) where T : Component
+			=> AddToPool(template.gameObject, transform, count);
 
-		public bool AddToPool(GameObject prefab, int count, Transform parent)
+		public bool AddToPool<T>(T template, Transform parent, int count) where T : Component	
+			=> AddToPool(template.gameObject, parent, count);
+
+		public bool AddToPool(GameObject template, int count)
+			=> AddToPool(template, transform, count);
+
+		public bool AddToPool(GameObject template, Transform parent, int count)
 		{
-			if (prefab == null || count <= 0 || _destroyed)
+			if (template == null || count <= 0 || _destroyed)
 			{
 				return false;
 			}
 
 			for (int i = 0; i < count; i++)
 			{
-				GameObject obj = CreateObject(prefab, parent);
-				PushToPool(obj, prefab, parent);
+				GameObject obj = CreateObject(template, parent);
+				PushToPool(obj, template, parent);
 			}
 
 			return true;
 		}
 
-		public GameObject PopFromPool(GameObject prefab, bool forceCreate = false, Vector3 position = default)
-			=> PopFromPool(prefab, transform, forceCreate, position);
+		public T PopFromPool<T>(T template, bool forceCreate = false, Vector3 position = default) where T : Component
+			=> PopFromPool<T>(template.gameObject, forceCreate, transform, position);
+
+		public T PopFromPool<T>(T template, Transform parent, bool forceCreate = false, Vector3 position = default) where T : Component			
+			=> PopFromPool<T>(template.gameObject, forceCreate, parent, position);
+
+
+		public T PopFromPool<T>(T template, bool forceCreate = false, Transform parent = null, Vector3 position = default) where T : Component
+			=> PopFromPool<T>(template.gameObject, forceCreate, parent, position);
+
+		public T PopFromPool<T>(GameObject template, bool forceCreate = false, Transform parent = null, Vector3 position = default)
+			where T : Component
+		{
+			if (!template.TryGetComponent(out T component))
+			{
+				PLog.Error<UtilityLogger>("Cannot pop from pool: This template does not have the correct component");
+				return null;
+			}
 			
-		public GameObject PopFromPool(GameObject prefab, Transform parent, bool forceCreate = false, Vector3 position = default)
+			GameObject obj = PopFromPool(template, parent, forceCreate, position);
+
+			if (obj != null && obj.TryGetComponent(out component))
+				return component;
+			return null;
+		}
+
+		public GameObject PopFromPool(GameObject template, bool forceCreate = false, Vector3 position = default)
+			=> PopFromPool(template, transform, forceCreate, position);
+			
+		public GameObject PopFromPool(GameObject template, Transform parent, bool forceCreate = false, Vector3 position = default)
 		{
 			GameObject obj = null;
 			if (forceCreate)
 			{
-				obj = CreateObject(prefab, null);
+				obj = CreateObject(template, null);
 			}
 			else
 			{
-				Queue<GameObject> queue = FindInContainer(prefab);
+				Queue<GameObject> queue = FindInContainer(template);
 				if (queue.Count > 0)
 				{
 					obj = queue.Dequeue();
@@ -127,70 +157,56 @@ namespace Rhinox.Utilities
 			}
 
 			if (obj == null)
-				obj = CreateObject(prefab, parent, position);
+				obj = CreateObject(template, parent, position);
 
 			if (obj.TryGetComponent(out IPoolableObject o))
 			{
-				o.Prefab = prefab;
+				o.Template = template;
 				o.Init();
 			}
 			
 			return obj;
 		}
-		
-		
-		public T PopFromPool<T>(T prefab, bool forceCreate = false, Vector3 position = default)
-			where T : Component
-			=> PopFromPool<T>(prefab.gameObject, forceCreate, transform, position);
 
-		public T PopFromPool<T>(T prefab, Transform parent, bool forceCreate = false, Vector3 position = default)
-			where T : Component			
-			=> PopFromPool<T>(prefab.gameObject, forceCreate, parent, position);
-
-
-		public T PopFromPool<T>(T prefab, bool forceCreate = false, Transform parent = null, Vector3 position = default)
-			where T : Component
-			=> PopFromPool<T>(prefab.gameObject, forceCreate, parent, position);
-
-		public T PopFromPool<T>(GameObject prefab, bool forceCreate = false, Transform parent = null, Vector3 position = default)
-			where T : Component
+		private Queue<GameObject> FindInContainer(GameObject template)
 		{
-			if (!prefab.TryGetComponent(out T component))
+			if (_objectsByTemplate.ContainsKey(template) == false)
 			{
-				PLog.Error<UtilityLogger>("Cannot pop from pool: This prefab does not have the correct component");
-				return null;
-			}
-			
-			GameObject obj = PopFromPool(prefab, parent, forceCreate, position);
-
-			if (obj != null && obj.TryGetComponent(out component))
-				return component;
-			return null;
-		}
-
-		private Queue<GameObject> FindInContainer(GameObject prefab)
-		{
-			if (_container.ContainsKey(prefab) == false)
-			{
-				_container.Add(prefab, new Queue<GameObject>());
+				_objectsByTemplate.Add(template, new Queue<GameObject>());
 			}
 
-			return _container[prefab];
+			return _objectsByTemplate[template];
 		}
 
-		private GameObject CreateObject(GameObject prefab, Transform parent, Vector3 position = default)
-			=> CreateObject(prefab, parent, position, Quaternion.identity);
+		private GameObject CreateObject(GameObject template, Transform parent, Vector3 position = default)
+			=> CreateObject(template, parent, position, Quaternion.identity);
 		
-		private GameObject CreateObject(GameObject prefab, Transform parent, Vector3 position, Quaternion rotation)
+		private GameObject CreateObject(GameObject template, Transform parent, Vector3 position, Quaternion rotation)
 		{
-			var newObj = Instantiate(prefab, position, rotation);
-			newObj.name = prefab.name;
+			var newObj = Instantiate(template, position, rotation);
+			newObj.name = template.name;
 			newObj.transform.SetParent(parent, false);
 			return newObj;
 		}
 
-		public void PushToPool(GameObject obj)
-			=> PushToPool(obj, transform);
+		public void PushToPool<T>(T obj, bool preserveParent = true) where T : Component
+			=> PushToPool(obj.gameObject, preserveParent);
+
+		public void PushToPool<T>(T obj, Transform parent) where T : Component
+			=> PushToPool(obj.gameObject, parent);
+		
+		public void PushToPool<T>(T obj, T template) where T : Component
+			=> PushToPool(obj.gameObject, template.gameObject, transform);
+
+		public void PushToPool<T>(T obj, T template, Transform parent) where T : Component
+			=> PushToPool(obj.gameObject, template.gameObject, parent);
+
+		public void PushToPool(GameObject obj, bool preserveParent = true)
+		{
+			if (obj == null) return;
+
+			PushToPool(obj, preserveParent ? obj.transform.parent : transform);
+		}
 
 		public void PushToPool(GameObject obj, Transform parent)
 		{
@@ -199,55 +215,46 @@ namespace Rhinox.Utilities
 			obj.SetActive(false);
 			obj.transform.SetParent(parent, false);
 
-			if (ValidateObjectAsPoolable(obj, out GameObject prefab))
+			if (ValidateObjectAsPoolable(obj, out GameObject template))
 			{
-				Queue<GameObject> queue = FindInContainer(prefab);
+				Queue<GameObject> queue = FindInContainer(template);
 				queue.Enqueue(obj);
 			}
 		}
 
-		private bool ValidateObjectAsPoolable(GameObject obj, out GameObject prefab)
+		private bool ValidateObjectAsPoolable(GameObject obj, out GameObject template)
 		{
 			if (obj.TryGetComponent(out IPoolableObject poolObject))
 			{
-				prefab = poolObject.Prefab;
+				template = poolObject.Template;
 
-				if (prefab != null)
+				if (template != null)
 					return true;
 				
 				PLog.Error<UtilityLogger>("Pushed an object into pool with with an uninitialized IPoolObject. " +
-				                          "Use the function that provides a prefab context instead");
+				                          "Use the function that provides a template context instead");
 				return false;
 			}
 			
-			prefab = null;
+			template = null;
 			PLog.Error<UtilityLogger>("Pushed an object into pool with no IPoolObject behaviour. " +
-			                          "Use the function that provides a prefab context instead");
+			                          "Use the function that provides a template context instead");
 			return false;
 		}
 
-		public void PushToPool(GameObject obj, GameObject prefab)
-			=> PushToPool(obj, prefab, transform);
+		public void PushToPool(GameObject obj, GameObject template)
+			=> PushToPool(obj, template, transform);
 
-		public void PushToPool(GameObject obj, GameObject prefab, Transform parent)
+		public void PushToPool(GameObject obj, GameObject template, Transform parent)
 		{
 			if (obj == null || _destroyed) return;
 
 			obj.SetActive(false);
 			obj.transform.SetParent(parent, false);
 
-			Queue<GameObject> queue = FindInContainer(prefab);
+			Queue<GameObject> queue = FindInContainer(template);
 			queue.Enqueue(obj);
 		}
-		
-		public void PushToPool<T>(T obj) where T : Component => PushToPool(obj.gameObject, transform);
-
-		public void PushToPool<T>(T obj, Transform parent) where T : Component => PushToPool(obj.gameObject, parent);
-		
-		public void PushToPool<T>(T obj, T prefab) where T : Component => PushToPool(obj.gameObject, prefab.gameObject, transform);
-
-		public void PushToPool<T>(T obj, T prefab, Transform parent) where T : Component
-			=> PushToPool(obj.gameObject, prefab.gameObject, parent);
 
 		public void PushToPoolDelayed(GameObject obj, float time)
 			=> PushToPoolDelayed(obj, time, transform);
@@ -257,15 +264,15 @@ namespace Rhinox.Utilities
 			if (obj == null)
 				return;
 			
-			if (ValidateObjectAsPoolable(obj, out GameObject prefab))
-				PushToPoolDelayed(obj, prefab, time, parent);
+			if (ValidateObjectAsPoolable(obj, out GameObject template))
+				PushToPoolDelayed(obj, template, time, parent);
 		}
 
-		public void PushToPoolDelayed(GameObject obj, GameObject prefab, float time)
-			=> PushToPoolDelayed(obj, prefab, time, transform);
+		public void PushToPoolDelayed(GameObject obj, GameObject template, float time)
+			=> PushToPoolDelayed(obj, template, time, transform);
 
-		public void PushToPoolDelayed(GameObject obj, GameObject prefab, float time, Transform parent)
-			=> ManagedCoroutine.Begin(PushToPoolDelayedEnumerator(obj, prefab, time, parent));
+		public void PushToPoolDelayed(GameObject obj, GameObject template, float time, Transform parent)
+			=> ManagedCoroutine.Begin(PushToPoolDelayedEnumerator(obj, template, time, parent));
 
 		public void PushToPoolDelayed<T>(T obj, float time)
 			where T : Component
@@ -275,31 +282,31 @@ namespace Rhinox.Utilities
 			where T : Component
 			=> PushToPoolDelayed(obj.gameObject, time, parent);
 		
-		public void PushToPoolDelayed<T>(T obj, T prefab, float time)
+		public void PushToPoolDelayed<T>(T obj, T template, float time)
 			where T : Component
-			=> PushToPoolDelayed(obj.gameObject, prefab.gameObject, time, transform);
+			=> PushToPoolDelayed(obj.gameObject, template.gameObject, time, transform);
 
-		public void PushToPoolDelayed<T>(T obj, T prefab, float time, Transform parent)
+		public void PushToPoolDelayed<T>(T obj, T template, float time, Transform parent)
 			where T : Component
-			=> PushToPoolDelayed(obj.gameObject, prefab.gameObject, time, parent);
+			=> PushToPoolDelayed(obj.gameObject, template.gameObject, time, parent);
 
-		private IEnumerator PushToPoolDelayedEnumerator(GameObject obj, GameObject prefab, float secondsUntilPush, Transform parent)
+		private IEnumerator PushToPoolDelayedEnumerator(GameObject obj, GameObject template, float secondsUntilPush, Transform parent)
 		{
 			yield return new WaitForSeconds(secondsUntilPush);
-			PushToPool(obj, prefab, parent: parent);
+			PushToPool(obj, template, parent: parent);
 		}
 
 		/// <summary>
 		/// Releases the pool from all items.
 		/// </summary>
-		/// <param name="prefab">The prefab to be used to find the items.</param>
+		/// <param name="template">The template to be used to find the items.</param>
 		/// <param name="destroyObjects">If set to <c>true</c> destroy object, else object is removed from pool but kept in scene. </param>
-		public void ReleaseItems(GameObject prefab, bool destroyObjects = false)
+		public void ReleaseItems(GameObject template, bool destroyObjects = false)
 		{
-			if (prefab == null)
+			if (template == null)
 				return;
 
-			Queue<GameObject> queue = FindInContainer(prefab);
+			Queue<GameObject> queue = FindInContainer(template);
 			
 			if (queue == null)
 				return;
@@ -317,7 +324,7 @@ namespace Rhinox.Utilities
 		/// </summary>
 		public void ReleasePool()
 		{
-			foreach (var kvp in _container)
+			foreach (var kvp in _objectsByTemplate)
 			{
 				Queue<GameObject> queue = kvp.Value;
 				while (queue.Count > 0)
@@ -327,8 +334,8 @@ namespace Rhinox.Utilities
 				}
 			}
 
-			_container = null;
-			_container = new Dictionary<GameObject, Queue<GameObject>>();
+			_objectsByTemplate = null;
+			_objectsByTemplate = new Dictionary<GameObject, Queue<GameObject>>();
 		}
 	}
 }

--- a/Assets/Utilities/ObjectPool/ObjectPool.cs
+++ b/Assets/Utilities/ObjectPool/ObjectPool.cs
@@ -23,12 +23,12 @@ namespace Rhinox.Utilities
 
 		void PushToPool(GameObject obj, bool preserveParent = true);
 		void PushToPool(GameObject obj, Transform parent);
-		void PushToPool(GameObject obj, GameObject template);
+		void PushToPool(GameObject obj, GameObject template, bool preserveParent = true);
 		void PushToPool(GameObject obj, GameObject template, Transform parent);
 		
 		void PushToPool<T>(T obj, bool preserveParent = true) where T : Component;
 		void PushToPool<T>(T obj, Transform parent) where T : Component;
-		void PushToPool<T>(T obj, T template) where T : Component;
+		void PushToPool<T>(T obj, T template, bool preserveParent = true) where T : Component;
 		void PushToPool<T>(T obj, T template, Transform parent) where T : Component;
 
 		void PushToPoolDelayed(GameObject obj, float time);
@@ -142,7 +142,7 @@ namespace Rhinox.Utilities
 			GameObject obj = null;
 			if (forceCreate)
 			{
-				obj = CreateObject(template, null);
+				obj = CreateObject(template, parent);
 			}
 			else
 			{
@@ -160,10 +160,7 @@ namespace Rhinox.Utilities
 				obj = CreateObject(template, parent, position);
 
 			if (obj.TryGetComponent(out IPoolableObject o))
-			{
-				o.Template = template;
-				o.Init();
-			}
+				o.Init(this, template);
 			
 			return obj;
 		}
@@ -195,8 +192,8 @@ namespace Rhinox.Utilities
 		public void PushToPool<T>(T obj, Transform parent) where T : Component
 			=> PushToPool(obj.gameObject, parent);
 		
-		public void PushToPool<T>(T obj, T template) where T : Component
-			=> PushToPool(obj.gameObject, template.gameObject, transform);
+		public void PushToPool<T>(T obj, T template, bool preserveParent = true) where T : Component
+			=> PushToPool(obj.gameObject, template.gameObject, preserveParent);
 
 		public void PushToPool<T>(T obj, T template, Transform parent) where T : Component
 			=> PushToPool(obj.gameObject, template.gameObject, parent);
@@ -242,8 +239,8 @@ namespace Rhinox.Utilities
 			return false;
 		}
 
-		public void PushToPool(GameObject obj, GameObject template)
-			=> PushToPool(obj, template, transform);
+		public void PushToPool(GameObject obj, GameObject template, bool preserveParent = true)
+			=> PushToPool(obj, template, preserveParent ? obj.transform.parent : transform);
 
 		public void PushToPool(GameObject obj, GameObject template, Transform parent)
 		{

--- a/Assets/Utilities/ObjectPool/PoolObject.cs
+++ b/Assets/Utilities/ObjectPool/PoolObject.cs
@@ -4,7 +4,7 @@ namespace Rhinox.Utilities
 {
 	public interface IPoolableObject
 	{
-		GameObject Prefab { get; set; }
+		GameObject Template { get; set; }
 		void Init();
 	}
 
@@ -15,7 +15,7 @@ namespace Rhinox.Utilities
 			get { return ObjectPool.Instance; }
 		}
 
-		public GameObject Prefab { get; set; }
+		public GameObject Template { get; set; }
 
 		public virtual void Init()
 		{

--- a/Assets/Utilities/ObjectPool/PoolObject.cs
+++ b/Assets/Utilities/ObjectPool/PoolObject.cs
@@ -4,21 +4,30 @@ namespace Rhinox.Utilities
 {
 	public interface IPoolableObject
 	{
-		GameObject Template { get; set; }
-		void Init();
+		GameObject Template { get; }
+		void Init(IObjectPool pool, GameObject template);
 	}
 
 	public class PoolObject : MonoBehaviour, IPoolableObject
 	{
-		protected IObjectPool Pool
+		protected IObjectPool Pool { get; private set; }
+
+		public GameObject Template { get; private set; }
+
+		public virtual void Init(IObjectPool pool, GameObject template)
 		{
-			get { return ObjectPool.Instance; }
+			Template = template;
+			Pool = pool;
+		}
+		
+		public void PushBackToPool(bool preserveParent = true)
+		{
+			Pool.PushToPool(gameObject, Template, preserveParent);
 		}
 
-		public GameObject Template { get; set; }
-
-		public virtual void Init()
+		public void PushBackToPool(Transform parent)
 		{
+			Pool.PushToPool(gameObject, Template, parent);
 		}
 	}
 }

--- a/Assets/Utilities/ObjectPool/PooledFx.cs
+++ b/Assets/Utilities/ObjectPool/PooledFx.cs
@@ -21,7 +21,7 @@ namespace Rhinox.Utilities
 
 		public void Update()
 		{
-			if (Prefab && AddToPoolWhenDead && _systems.All(x => !x.IsAlive()))
+			if (Template && AddToPoolWhenDead && _systems.All(x => !x.IsAlive()))
 			{
 				gameObject.SetActive(false);
 				Pool.PushToPool(gameObject);

--- a/Assets/Utilities/ObjectPool/PooledFx.cs
+++ b/Assets/Utilities/ObjectPool/PooledFx.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using Rhinox.Lightspeed;
 using UnityEngine;
 
 namespace Rhinox.Utilities
@@ -9,11 +10,6 @@ namespace Rhinox.Utilities
 
 		private ParticleSystem[] _systems;
 
-		public override void Init()
-		{
-			gameObject.SetActive(true);
-		}
-
 		public void Awake()
 		{
 			_systems = GetComponentsInChildren<ParticleSystem>();
@@ -22,10 +18,7 @@ namespace Rhinox.Utilities
 		public void Update()
 		{
 			if (Template && AddToPoolWhenDead && _systems.All(x => !x.IsAlive()))
-			{
-				gameObject.SetActive(false);
-				Pool.PushToPool(gameObject);
-			}
+				PushBackToPool();
 		}
 
 		[ContextMenu("Emit Once")]

--- a/Assets/Utilities/ObjectPool/TimedPoolObject.cs
+++ b/Assets/Utilities/ObjectPool/TimedPoolObject.cs
@@ -1,0 +1,25 @@
+using System;
+using UnityEngine;
+
+namespace Rhinox.Utilities
+{
+    public class TimedPoolObject : PoolObject
+    {
+        private DateTime _startupTime;
+
+        public float SecondsBeforeReturningToPool;
+
+        public override void Init(IObjectPool pool, GameObject template)
+        {
+            base.Init(pool, template);
+            _startupTime = DateTime.Now;
+        }
+
+        private void Update()
+        {
+            var time = DateTime.Now - _startupTime;
+            if (time.TotalSeconds >= SecondsBeforeReturningToPool)
+                PushBackToPool();
+        }
+    }
+}

--- a/Assets/Utilities/ObjectPool/TimedPoolObject.cs.meta
+++ b/Assets/Utilities/ObjectPool/TimedPoolObject.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e0227024feb7497aa8ee3910767d5842
+timeCreated: 1682769330

--- a/Assets/Utilities/com.rhinox.open.utilities.asmdef
+++ b/Assets/Utilities/com.rhinox.open.utilities.asmdef
@@ -19,6 +19,11 @@
             "name": "com.unity.textmeshpro",
             "expression": "0.0.0",
             "define": "TEXT_MESH_PRO"
+        },
+        {
+            "name": "com.unity.nuget.newtonsoft-json",
+            "expression": "0.0.0",
+            "define": "NEWTONSOFT"
         }
     ],
     "noEngineReferences": false

--- a/Assets/Utilities/package.json
+++ b/Assets/Utilities/package.json
@@ -1,8 +1,8 @@
 {
   "name": "com.rhinox.open.utilities",
   "displayName": "Rhinox.Utilities",
-  "version": "1.5.4",
-  "unity": "2019.3",
+  "version": "1.6.0",
+  "unity": "2019.4",
   "description": "Utility code for Unity projects.",
   "keywords": [
     "unity",
@@ -11,8 +11,8 @@
   ],
   "category": "Unity",
   "dependencies": {
-	"com.rhinox.open.lightspeed": "1.5.5",
-	"com.rhinox.open.guiutils": "2.7.0",
+	"com.rhinox.open.lightspeed": "1.5.11",
+	"com.rhinox.open.guiutils": "2.10.0",
 	"com.rhinox.open.perceptor": "0.2.0"
   },
   "repository": {

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -13,6 +13,7 @@
 	"com.rhinox.open.lightspeed": "1.5.5",
 	"com.rhinox.open.guiutils": "2.7.0",
     "com.rhinox.open.perceptor": "0.2.0",
+	"com.unity.nuget.newtonsoft-json": "2.0.0",
 	"com.unity.2d.sprite": "1.0.0",
     "com.unity.editorcoroutines": "1.0.0",
     "com.unity.ext.nunit": "1.0.6",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -10,8 +10,8 @@
     }
   ],
   "dependencies": {
-	"com.rhinox.open.lightspeed": "1.5.5",
-	"com.rhinox.open.guiutils": "2.7.0",
+	"com.rhinox.open.lightspeed": "1.5.11",
+	"com.rhinox.open.guiutils": "2.10.0",
     "com.rhinox.open.perceptor": "0.2.0",
 	"com.unity.nuget.newtonsoft-json": "2.0.0",
 	"com.unity.2d.sprite": "1.0.0",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -13,7 +13,7 @@
 	"com.rhinox.open.lightspeed": "1.5.5",
 	"com.rhinox.open.guiutils": "2.7.0",
     "com.rhinox.open.perceptor": "0.2.0",
-    "com.unity.2d.sprite": "1.0.0",
+	"com.unity.2d.sprite": "1.0.0",
     "com.unity.editorcoroutines": "1.0.0",
     "com.unity.ext.nunit": "1.0.6",
     "com.unity.ide.rider": "1.2.1",


### PR DESCRIPTION
### Added
- CustomProjectSettings.FullSettingsPath: Absolute settings path
- Support for SkinnedMeshRenderer in PolyCounter
- Search support in ScriptableObjectCreator
- AdvancedSceneSearchOverview: Added PrefabStageUtility in parsing
- FindDependencies: AddSelection button added
- ApiHelper: Get and Post request helper class for API's
- Newtonsoft JSON as optional dependency (used in ApiHelper)

### Modified
- Added basic support for BetterEvents: BetterEventEntry labels, handling serialization of BetterEventEntry through Unity
- AdvancedSceneSearchOverview, TexturePacker, UnityIconsViewer: Reworked to support repaints in odin-less context
- Obsolete SlidePagedWindowNavigationHelper removed and replaced by SlidePageNavigationHelper
- AdvancedSceneSearchResults: Uses paging now
- ManagedCoroutine: Introduced new preferred static Begin() method to start Coroutines instead of using the constructor
- ManagedCoroutine: now detects exception and triggers an event callback (OnFailed) when they occur
- ObjectPool: IPoolableObject is no longer a mandatory interface when you want to use pooling

### Fixes
- Fix for refreshing CustomProjectSettings bug (write time update loop)
- LoadableConfigFile not being initialized when calling Save
- LoadableConfigFile becoming unloadable when exception occurs during initialize/load
- TransformCompEditor not reading MenuItems correctly (menuItem -> Path) for overrides
- Fix null ref on EditorCoroutineRunner.KillAllCoroutines